### PR TITLE
Don't ask if plaintiff/defendant and then ignore it

### DIFF
--- a/docassemble/Interpreternotice/data/questions/interpreter_notice_standalone.yml
+++ b/docassemble/Interpreternotice/data/questions/interpreter_notice_standalone.yml
@@ -34,7 +34,7 @@ code: |
   interview_short_title = 'Ask the Court for an interpreter'
 ---
 code: |
-  al_form_type = 'starts_case'
+  al_form_type = 'existing_case'
 ---
 features:
   navigation: True

--- a/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
+++ b/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
@@ -53,8 +53,6 @@ code: |
   # Set the allowed courts for this interview
   allowed_courts = interview_metadata["InterpreterNotice__with_variables"]["allowed courts"]
   nav.set_section('review_InterpreterNotice__with_variables')
-  # Below sets the user_role by asking a question.
-  # You can set user_role directly instead to either 'plaintiff' or 'defendant'
   user_role
   users.gather()
   other_parties.gather()

--- a/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
+++ b/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
@@ -55,7 +55,7 @@ code: |
   nav.set_section('review_InterpreterNotice__with_variables')
   # Below sets the user_role by asking a question.
   # You can set user_role directly instead to either 'plaintiff' or 'defendant'
-  user_ask_role
+  user_role
   users.gather()
   other_parties.gather()
   users[0].address.address

--- a/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
+++ b/docassemble/Interpreternotice/data/questions/interpreter_notice_to_include.yml
@@ -53,7 +53,7 @@ code: |
   # Set the allowed courts for this interview
   allowed_courts = interview_metadata["InterpreterNotice__with_variables"]["allowed courts"]
   nav.set_section('review_InterpreterNotice__with_variables')
-  user_role
+  user_ask_role
   users.gather()
   other_parties.gather()
   users[0].address.address


### PR DESCRIPTION
Fixes #19.

Currently, we will ask if the user is a plaintiff or defendant because we directly trigger `user_ask_role`. However, the user's answer to the question is ignored, because `al_form_type = "starts_case"`; so the AL will mark `user_starts_case` as True.  I think "starts_case" is incorrect for this form, so I changed it to "existing_case", and changed `user_ask_role` to `user_role`, which will still trigger the same question, but won't ask it if the form this is being used in already knows `user_role`. 

Tested on AL main and https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/596. 